### PR TITLE
Add poetry project definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[tool.poetry]
+name = "einfuehrung-in-jupyter-notebooks"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+jupyterlab = "^3.0.10"
+jupyterlab-lsp = "^3.4.1"
+pandas = "^1.2.3"
+matplotlib = "^3.3.4"
+folium = "^0.12.1"
+ipycytoscape = "^1.2.0"
+ipywidgets = "^7.6.3"
+ipycanvas = "^0.8.2"
+networkx = "^2.5"
+scipy = "^1.6.1"
+
+[tool.poetry.dev-dependencies]
+autopep8 = "^1.5.5"
+black = "^20.8b1"
+pyflakes = "^2.2.0"
+rope = "^0.18.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Hi,

I'm going to attend this coming Tuesday and had gone through the content in preparation. I have never used Anaconda and didn't want to install it for fear of it messing up my existing setup. For project dependency management and virtual environments, I use [`poetry`](https://python-poetry.org/). It works really well. As such, I took your config file:

https://github.com/1kastner/einfuehrung-in-jupyter-notebooks/blob/44fca25843b32e840a30c8f9355c6bfad1c58225/environment.yml

and basically implemented its equivalent poetry config file. One can then, after installing `poetry` itself, run `poetry install` to install the according virtual environment, then `poetry run jupyter-lab` to start `jupyter-lab` within that venv. So far, it works, and all notebooks currently contained in the repo run successfully. I'm on Python 3.9 and that also works fine. Including `pyproject.toml` could help other `poetry` users (probably no one..) to get started quickly.